### PR TITLE
#157174853 Refine user verification

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,5 +7,6 @@ omit =
     */tests/*
     */static/*
     *apps.py*
+    */distutils/*
 
 show_missing = True

--- a/api_v1/tests/test_models.py
+++ b/api_v1/tests/test_models.py
@@ -15,6 +15,9 @@ class BankingUserTestCase(TestCase):
         )
 
     def test_creating_banking_user(self):
+        """
+        Tests creation of a banking user.
+        """
         current_users = BankingUser.objects.count()
         BankingUser.objects.create_user(
             email='new_user@example.com',
@@ -27,6 +30,10 @@ class BankingUserTestCase(TestCase):
         self.assertEqual(new_user.national_id, '123456')
 
     def test_can_not_create_duplicate_email(self):
+        """
+        Tests that an exception is raised when
+        duplidate email is provided.
+        """
         BankingUser.objects.create_user(
             email='new_user@example.com',
             date_of_birth=self.date_of_birth,
@@ -40,6 +47,10 @@ class BankingUserTestCase(TestCase):
             )
 
     def test_can_not_create_duplicate_national_id(self):
+        """
+        Tests that an exception is raised when
+        duplidate national_id is provided.
+        """
         BankingUser.objects.create_user(
             email='new_user32@example.com',
             date_of_birth=self.date_of_birth,
@@ -58,7 +69,74 @@ class BankingUserTestCase(TestCase):
         verifying them.
         """
         self.assertFalse(self.test_user.is_verified)
-        self.test_user.verify()
+        self.test_user.verify('pass123')
         verified_user = BankingUser.objects.get(
             email='test_user@example.com')
         self.assertTrue(verified_user.is_verified)
+
+    def test_create_user_with_no_email(self):
+        """
+        Tests that an exception is raised when enail is not provided.
+        """
+        with self.assertRaises(ValueError):
+            BankingUser.objects.create_user(
+                date_of_birth=self.date_of_birth,
+                national_id='7910192'
+            )
+
+    def test_create_user_with_no_national_id(self):
+        """
+        Tests that an exception is raised when national_id is not provided.
+        """
+        with self.assertRaises(ValueError):
+            BankingUser.objects.create_user(
+                email='user@example.com',
+                date_of_birth=self.date_of_birth,
+            )
+
+    def test_create_user_with_no_date_of_birth(self):
+        """
+        Tests that an exception is raised when date of birth is not provided.
+        """
+        with self.assertRaises(ValueError):
+            BankingUser.objects.create_user(
+                email='user@example.com',
+                national_id='45261782'
+            )
+
+    def test_create_super_user(self):
+        """
+        Tests creation of a superuser.
+        """
+        BankingUser.objects.create_superuser(
+            email='admin@banking.com',
+            national_id='3239019',
+            date_of_birth=self.date_of_birth,
+        )
+        super_user = BankingUser.objects.get(email='admin@banking.com')
+        self.assertTrue(super_user.is_superuser)
+
+    def test_create_a_non_staff_super_user(self):
+        """
+        Tests that an exception is raised when is_staff=False.
+        """
+        with self.assertRaises(ValueError):
+            BankingUser.objects.create_superuser(
+                email='admin2@banking.com',
+                national_id='3039019',
+                date_of_birth=self.date_of_birth,
+                is_staff=False
+            )
+
+    def test_create_a_non_super_user(self):
+        """
+        Tests that an exception is raised when is_superuser=False.
+        """
+        with self.assertRaises(ValueError):
+            BankingUser.objects.create_superuser(
+                email='admin2@banking.com',
+                national_id='3039019',
+                date_of_birth=self.date_of_birth,
+                is_staff=True,
+                is_superuser=False
+            )


### PR DESCRIPTION
#### What does this PR do?
Modifies user verification to use one-time password.

#### Description of Task to be completed?
* Use the national_id to set a onetime password on creating a banking user
* Refine BankingUser.verify to verify once the one-time password has been updated.
* Refactor user verification tests

#### What are the relevant pivotal tracker stories?
[#157174853](https://www.pivotaltracker.com/story/show/157174853)
